### PR TITLE
fix: copy .npmrc to api/dist for Oryx npm install

### DIFF
--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -53,6 +53,7 @@ jobs:
           api_location: "api/dist"
           output_location: ""
           skip_app_build: true
+          skip_api_build: true
 
   close_pull_request_job:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'

--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -53,7 +53,7 @@ jobs:
           api_location: "api/dist"
           output_location: ""
           skip_app_build: true
-          skip_api_build: true
+          api_build_command: "echo 'API already built'"
 
   close_pull_request_job:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'

--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -40,6 +40,7 @@ jobs:
           cp main/function.json dist/main/function.json
           cp host.json dist/host.json
           cp package.json dist/package.json
+          cp .npmrc dist/.npmrc
 
       - name: Build and Deploy
         id: builddeploy


### PR DESCRIPTION
Oryx runs npm install --production in api/dist/ but .npmrc with legacy-peer-deps=true was only in api/ — causing install to fail.