### PR TITLE
feat: add SWA GitHub auth, restrict access to PorfirioR only

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
 import { ConfigModule } from '@nestjs/config';
 import { UtilityModule } from './utility/utility.module';
 import { HostModule } from './host/host.module';
+import { SwaAuthGuard } from './utility/guards/swa-auth.guard';
 
 @Module({
   imports: [
@@ -11,6 +13,9 @@ import { HostModule } from './host/host.module';
       envFilePath: '.env'
     }),
     HostModule
+  ],
+  providers: [
+    { provide: APP_GUARD, useClass: SwaAuthGuard },
   ],
 })
 export class AppModule {}

--- a/api/src/utility/guards/swa-auth.guard.ts
+++ b/api/src/utility/guards/swa-auth.guard.ts
@@ -1,0 +1,24 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException, ForbiddenException } from '@nestjs/common';
+
+const ALLOWED_USER = 'PorfirioR';
+
+@Injectable()
+export class SwaAuthGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const principalHeader = request.headers['x-ms-client-principal'];
+
+    if (!principalHeader) {
+      throw new UnauthorizedException();
+    }
+
+    const decoded = Buffer.from(principalHeader, 'base64').toString('utf-8');
+    const principal = JSON.parse(decoded);
+
+    if (principal.userDetails !== ALLOWED_USER) {
+      throw new ForbiddenException();
+    }
+
+    return true;
+  }
+}

--- a/spa/angular.json
+++ b/spa/angular.json
@@ -26,7 +26,8 @@
             "assets": [
               { "glob": "**/*", "input": "src/assets", "output": "assets" },
               { "glob": "favicon.ico", "input": "src", "output": "" },
-              { "glob": "manifest.webmanifest", "input": "src", "output": "" }
+              { "glob": "manifest.webmanifest", "input": "src", "output": "" },
+              { "glob": "staticwebapp.config.json", "input": "src", "output": "" }
             ],
             "styles": ["src/styles.css"],
             "scripts": []

--- a/spa/src/app/app.routes.ts
+++ b/spa/src/app/app.routes.ts
@@ -1,4 +1,5 @@
 import { Routes } from '@angular/router';
+import { authGuard } from './core/guards/auth.guard';
 
 export const routes: Routes = [
   {
@@ -7,7 +8,15 @@ export const routes: Routes = [
     pathMatch: 'full',
   },
   {
+    path: 'unauthorized',
+    loadComponent: () =>
+      import('./features/unauthorized/unauthorized.component').then(
+        m => m.UnauthorizedComponent,
+      ),
+  },
+  {
     path: 'groups',
+    canActivate: [authGuard],
     loadComponent: () =>
       import('./features/groups/components/group-list/group-list.component').then(
         m => m.GroupListComponent,
@@ -15,6 +24,7 @@ export const routes: Routes = [
   },
   {
     path: 'groups/:groupId',
+    canActivate: [authGuard],
     loadComponent: () =>
       import('./layout/group-shell/group-shell.component').then(
         m => m.GroupShellComponent,

--- a/spa/src/app/core/guards/auth.guard.ts
+++ b/spa/src/app/core/guards/auth.guard.ts
@@ -1,0 +1,23 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+
+export const authGuard: CanActivateFn = async () => {
+  const auth = inject(AuthService);
+  const router = inject(Router);
+
+  if (!auth.checked()) {
+    await auth.loadUser();
+  }
+
+  if (!auth.user()) {
+    auth.login();
+    return false;
+  }
+
+  if (!auth.isAuthorized()) {
+    return router.createUrlTree(['/unauthorized']);
+  }
+
+  return true;
+};

--- a/spa/src/app/core/services/auth.service.ts
+++ b/spa/src/app/core/services/auth.service.ts
@@ -1,0 +1,46 @@
+import { Injectable, inject, signal } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+
+export interface SwaUser {
+  userId: string;
+  userDetails: string;
+  identityProvider: string;
+  userRoles: string[];
+}
+
+const ALLOWED_USER = 'PorfirioR';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private http = inject(HttpClient);
+
+  user = signal<SwaUser | null>(null);
+  checked = signal(false);
+
+  async loadUser(): Promise<void> {
+    try {
+      const response = await firstValueFrom(
+        this.http.get<{ clientPrincipal: SwaUser | null }>('/.auth/me')
+      );
+      this.user.set(response.clientPrincipal);
+    } catch {
+      this.user.set(null);
+    } finally {
+      this.checked.set(true);
+    }
+  }
+
+  isAuthorized(): boolean {
+    const u = this.user();
+    return !!u && u.userDetails === ALLOWED_USER;
+  }
+
+  login(): void {
+    window.location.href = '/.auth/login/github';
+  }
+
+  logout(): void {
+    window.location.href = '/.auth/logout';
+  }
+}

--- a/spa/src/app/features/unauthorized/unauthorized.component.ts
+++ b/spa/src/app/features/unauthorized/unauthorized.component.ts
@@ -1,0 +1,30 @@
+import { Component, inject } from '@angular/core';
+import { AuthService } from '../../core/services/auth.service';
+
+@Component({
+  selector: 'app-unauthorized',
+  standalone: true,
+  template: `
+    <div class="min-h-screen flex items-center justify-center bg-base-200">
+      <div class="card w-96 bg-base-100 shadow-xl text-center">
+        <div class="card-body gap-4">
+          <span class="text-6xl">🔒</span>
+          <h2 class="card-title justify-center text-xl">Acceso denegado</h2>
+          @if (auth.user(); as user) {
+            <p class="text-base-content/60 text-sm">
+              Sesión iniciada como <strong>{{ user.userDetails }}</strong> pero no tenés permisos para acceder.
+            </p>
+          }
+          <div class="card-actions flex-col gap-2">
+            <button class="btn btn-error btn-sm w-full" (click)="auth.logout()">
+              Cerrar sesión
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  `,
+})
+export class UnauthorizedComponent {
+  auth = inject(AuthService);
+}

--- a/spa/src/staticwebapp.config.json
+++ b/spa/src/staticwebapp.config.json
@@ -1,0 +1,26 @@
+{
+  "routes": [
+    {
+      "route": "/.auth/login/github",
+      "allowedRoles": ["anonymous"]
+    },
+    {
+      "route": "/api/*",
+      "allowedRoles": ["authenticated"]
+    },
+    {
+      "route": "/*",
+      "allowedRoles": ["authenticated"]
+    }
+  ],
+  "responseOverrides": {
+    "401": {
+      "redirect": "/.auth/login/github",
+      "statusCode": 302
+    }
+  },
+  "navigationFallback": {
+    "rewrite": "/index.html",
+    "exclude": ["/assets/*", "/*.{css,scss,js,png,ico,webmanifest}"]
+  }
+}


### PR DESCRIPTION
- staticwebapp.config.json: require authenticated role on all routes, redirect 401 to /.auth/login/github
- Angular AuthService: calls /.auth/me, checks userDetails === PorfirioR
- Angular authGuard: loads user, redirects to /unauthorized if wrong user
- UnauthorizedComponent: shows logged-in user and logout button
- NestJS SwaAuthGuard: validates x-ms-client-principal header globally
- Applied guard via APP_GUARD in AppModule